### PR TITLE
Changed build and package commands to allow publishing on Firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,14 @@
   "scripts": {
     "dev": "plasmo dev",
     "lint": "eslint . --ext .ts,.tsx",
-    "build": "pnpm lint && plasmo build",
-    "package": "pnpm lint && plasmo package"
+    "build": "pnpm lint && plasmo build --hoist",
+    "build:firefox-mv2": "pnpm run build -- --target=firefox-mv2",
+    "build:firefox-mv3": "pnpm run build -- --target=firefox-mv3",
+    "build:chrome-mv3": "pnpm run build -- --target=chrome-mv3",
+    "package": "pnpm run build -- --zip",
+    "package:firefox-mv2": "pnpm run package -- --target=firefox-mv2",
+    "package:firefox-mv3": "pnpm run package -- --target=firefox-mv3",
+    "package:chrome-mv3": "pnpm run package -- --target=chrome-mv3"
   },
   "dependencies": {
     "@datastructures-js/priority-queue": "^6.3.2",


### PR DESCRIPTION
As mentioned in #7, since the problem is the app.js size, I simply added `--hoist` to reduce the bundle size. This passed all the Mozilla checks and now only brings up warnings which can be ignored. Your app does not need any other change to work on Firefox.
I also made command aliases for building and packaging on Chrome MV3, Firefox MV3 and Firefox MV2 for convenience.

All you have to do now to publish on Firefox is run :
```
pnpm package:firefox-mv2
```
Then just upload the generated Zip file